### PR TITLE
(16) Ajoute la première ADR dans le répertoire doc

### DIFF
--- a/doc/adr/001. Enregistrement des décisions concernant l'architecture dans des ADR.md
+++ b/doc/adr/001. Enregistrement des décisions concernant l'architecture dans des ADR.md
@@ -1,0 +1,43 @@
+# 001. Enregistrement des décisions concernant l'architecture dans des ADR
+
+Date : 2022-11-02
+
+## Contexte
+
+Sur ce projet, nous avons besoin de :
+
+- prendre des décisions concernant l'architecture facilement
+- prendre des décisions qui modifient des décisions précédentes facilement
+- savoir qu'une décision donnée a été modifiée ou remplacé par une décision ultérieure
+- pouvoir comprendre pourquoi une décision a été prise dans le passé
+
+## Décision
+
+Sur le projet PPG DITP, nous enregistrerons les décisions concernant l'architecture. Pour ces enregistrements, nous utiliserons le formalisme des ADR (Architecture Decision Records), telles que [décrites par Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions). Elles prendront la forme de fichiers Markdown et d’images. Elles seront stockées dans le même repository que le code.
+
+Ces enregistrements seront rédigés en français en général, et utiliseront les mêmes termes que dans nos conversations. À ce titre, des termes purement techniques que nous utilisons en anglais dans nos conversations resterons en anglais. Nous parlerons aussi d’ADR (Architecture Decision Record) pour désigner ces enregistrements, afin de conserver le lien avec le formalisme original.
+
+Ces enregistrements contiendront les sections suivantes :
+
+- Un **titre** court, avec des noms. Par exemple : "001. Enregistrement des décisions concernant l’architecture dans des ADR".
+- Une **Date**, la date du jour où la rédaction de l’ADR commence
+- Une section **Contexte** Cette section décrit les forces en présence, dont les forces technologiques, politiques, sociales, et spécifiques au projet. Ces forces sont probablement en tension, et ces tensions devraient être explicitées. Cette section utilise un langage neutre, elle décrit simplement des faits sans jugement.
+- Une section **Décision**.Cette section décrit notre réponse à ces forces. Elle se compose de phrases complètes, en forme active. “Nous enregistrerons…”
+- Une section **État**. Une décision peut être dans l’état *proposé* si les parties prenantes du projet ne l’ont pas encore acceptée, ou *acceptée* quand un accord a été obtenu. Si une ADR subséquente change ou annule une décision, elle peut prendre l’état *obsolète*, ou *annulée et remplacée*, avec une référence vers l’ADR qui la remplace.
+- Une section **Conséquences**. Cette section décrit le contexte résultant, après application de la décision. Toutes les conséquences devraient être listées, pas uniquement les conséquences positives. Une décision donnée peut avoir des conséquences positives, négatives et neutres, mais toutes touchent l’équipe et le projet dans le futur.
+
+## État
+
+Proposé.
+
+## Conséquences
+
+Une ADR décrit une décision importante pour un projet donné. Ça doit être quelque chose qui a des conséquences sur comment le reste du projet va se dérouler.
+
+Les conséquences d’une ADR sont susceptibles de devenir le contexte des ADRs suivantes.
+
+Les développeurs et développeuses du projet, ainsi que les parties prenantes, peuvent voir les ADRs, même quand la composition de l’équipe change avec le temps.
+
+Les raisons des décisions précédentes sont visibles par toutes et tous, présent et futur. On ne laisse personne se gratter la tête pour comprendre “À quoi pensaient iels ?” et le moment de changer d’anciennes décisions sera éclairé par les changements de contexte du projet. Autrement dit, le contexte et la logique des décisions seront documentés, et les personnes souhaitant prendre de nouvelles décisions ou modifier d’anciennes décisions pourront le faire en connaissance de cause.
+
+Voir l'article de Michael Nygard ci-dessus. Pour un outillage léger autour des ADR, voir [adr-tools](https://github.com/npryce/adr-tools) de Nat Pryce.


### PR DESCRIPTION
## Problème

Dans un projet, au fil du temps il devient difficile de comprendre pourquoi les décisions techniques ont été prises à l'époque, et dans quel contexte elles ont été prises.

## Solution

Cette PR propose un formalisme pour enregistrer les décisions concernant l'architecture, et le contexte dans lequel elles ont été prises.

Voir la première ADR, qui se décrit elle-même, pour plus d'informations.